### PR TITLE
[Refactor Models] Cast date columns to date type and coalesce 'numar' and 'numar_vechi' to one column

### DIFF
--- a/dbt/.gitignore
+++ b/dbt/.gitignore
@@ -2,3 +2,4 @@
 target/
 dbt_packages/
 logs/
+profiles.yml

--- a/dbt/models/dosare/models/stg_dosare.sql
+++ b/dbt/models/dosare/models/stg_dosare.sql
@@ -2,8 +2,9 @@ with source as (
     select 
         scj.numar as numar,
         scj.numarvechi as numar_vechi,
+        coalesce(scj.numar, scj.numarvechi) as numar_1,
         scj.obiect as obiect,
-        scj.datainitiala as data_initiala,
+        to_date(scj.datainitiala, 'YYYY-MM-DD') as data_initiala,
         stadiuprocesual as stadiu_procesual,
         categoriecaz as categorie_caz,
         stadiulprocesualcombinat as stadiul_procesual_combinat,
@@ -13,8 +14,9 @@ with source as (
     select
         numar,
         numar_vechi,
+        coalesce(numar, numar_vechi) as numar_1,
         obiect,
-        data_initial as data_initiala,
+        to_date(data_initial, 'YYYY-MM-DD') as data_initiala,
         null as stadiu_procesual,
         null as categorie_caz,
         null as stadiul_procesual_combinat,
@@ -24,3 +26,5 @@ with source as (
 
 select distinct *
 from source
+
+

--- a/dbt/models/dosare/models/stg_dosare_parti.sql
+++ b/dbt/models/dosare/models/stg_dosare_parti.sql
@@ -1,23 +1,15 @@
 with source as (
-    select 
-        just.nume,
-        just.calitate_parte,
-        just.numar,
-        scj.data as data,
-        scj.calitateaprocesualaanterioara as calitate_parte_anterioara
-    from {{source('dosare_raw', 'parti_dosare_just_ro')}} just
-    left join {{source('dosare_raw', 'scj_parti')}} scj
-        on trim(lower(just.calitate_parte)) = trim(lower(scj.calitateaprocesualacurenta))
-        and trim(lower(just.nume)) = trim(lower(scj.nume))
-    union all
     select
         nume,
         calitateaprocesualacurenta as calitate_parte,
-        null as numar,
-        data,
+        coalesce(numar, numarvechi) as numar_1,
+        to_date(parte.data, 'YYYY-MM-DD') as data,
         calitateaprocesualaanterioara as calitate_parte_anterioara
-    from {{source('dosare_raw', 'scj_parti')}}
+    from {{source('dosare_raw', 'scj_parti')}} parte
+    left join {{source('dosare_raw', 'scj')}} dosar
+        on parte._airbyte_scj_hashid = dosar._airbyte_scj_hashid
 )
 
 select distinct *
 from source
+

--- a/dbt/models/dosare/models/stg_dosare_sedinte.sql
+++ b/dbt/models/dosare/models/stg_dosare_sedinte.sql
@@ -1,6 +1,6 @@
 with source as (
     select 
-        data,
+        to_date(data, 'YYYY-MM-DD') as data,
         ora,
         solutie,
         numar_document,

--- a/dbt/models/dosare/schema/schema.yml
+++ b/dbt/models/dosare/schema/schema.yml
@@ -30,7 +30,7 @@ models:
         description: Calitatea părții din dosar
         tests:
           - not_null
-      - name: numar
+      - name: numar_1
         description: Numar dosar.
         tests:
           - not_null

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,12 +1,12 @@
 opendataexplorer:
   outputs:
     dev:
-      dbname: opendataexplorer
-      host: opendataexplorer.aware.ro
-      port: 11028
-      schema: public
+      dbname: db_name
+      host: hostname
+      port: 5432
+      schema: db_schema
       threads: 1
-      user: "el_user1"
-      pass: "n6WFoztWL1EDN7XRVOXlLlzlFWGNv0RV6W8dyyZFR9qAAA2XbHTqz8OKh7nlBIaR3Xab8lkAOXoTDloyxpOelA9b775T"
+      user: "{{ env_var('user_dev') }}"
+      pass: "{{ env_var('pass_dev') }}"
       type: postgres
   target: dev


### PR DESCRIPTION
This PR refactors the currently existing models, by casting the date fields to a date type and coalesces 'numar' and 'numar_vechi' from all models to only one column.
Additionally profiles.yml was added to dbt/.gitignore